### PR TITLE
Adding the ability to tell the Indicator class not to lowercase indicators.

### DIFF
--- a/csirtg_indicator/indicator.py
+++ b/csirtg_indicator/indicator.py
@@ -31,8 +31,8 @@ class Indicator(object):
 
     def __init__(self, indicator=None, version=PROTOCOL_VERSION, **kwargs):
         self.version = version
-        self._lowercase = False
-        self._lowercase = kwargs.get('lowercase', False)
+        self._lowercase = True
+        self._lowercase = kwargs.get('lowercase', True)
 
         for k in FIELDS:
             if k in ['indicator', 'confidence', 'count']:  # handle this at the end

--- a/test/test_indicator.py
+++ b/test/test_indicator.py
@@ -3,6 +3,7 @@ import json
 from csirtg_indicator.exceptions import InvalidIndicator
 from random import randint, uniform
 
+
 def test_indicator_ipv4():
     i = Indicator('192.168.1.1')
     assert i.is_private()
@@ -23,6 +24,30 @@ def test_indicator_url():
 
     assert i.is_private() is False
     assert i.indicator == 'http://example.org'
+    assert i.itype is not 'fqdn'
+    assert i.itype is 'url'
+    assert 'botnet' in i.tags
+    assert 'malware' in i.tags
+
+
+def test_indicator_mixedcase_lower_false():
+    i = Indicator('http://example.org/MiXeDCaSe',
+                  tags='botnet,malware', lowercase=False)
+
+    assert i.is_private() is False
+    assert i.indicator == 'http://example.org/MiXeDCaSe'
+    assert i.itype is not 'fqdn'
+    assert i.itype is 'url'
+    assert 'botnet' in i.tags
+    assert 'malware' in i.tags
+
+
+def test_indicator_mixedcase_lower_true():
+    i = Indicator('http://example.org/MiXeDCaSe',
+                  tags='botnet,malware', lowercase=True)
+
+    assert i.is_private() is False
+    assert i.indicator == 'http://example.org/mixedcase'
     assert i.itype is not 'fqdn'
     assert i.itype is 'url'
     assert 'botnet' in i.tags
@@ -68,7 +93,8 @@ def test_format_indicator():
 
 
 def test_indicator_dest():
-    i = Indicator(indicator='192.168.1.1', dest='10.0.0.1', portlist="23", protocol="tcp", dest_portlist='21,22-23')
+    i = Indicator(indicator='192.168.1.1', dest='10.0.0.1',
+                  portlist="23", protocol="tcp", dest_portlist='21,22-23')
     assert i.dest
     assert i.dest_portlist
 


### PR DESCRIPTION
We have a use case where we want indicators to keep their case (ie MiXeDCase is not changed to mixedcase).  
The worst culprit is URLs where case seems to matter.

We add another argument (lowercase= ) to the Indicator constructor to tell the class if it should apply the existing calls to .lower() if set to True. If this is set to False then the .lower() calls are bypassed.
I've ensured that the default behaviour is to lowercase things to minimise impact on others (ie default is lowercase=True).

Unit tests also included.