### PR TITLE
Replace newlines before outputting

### DIFF
--- a/csirtg_indicator/format/zzeek.py
+++ b/csirtg_indicator/format/zzeek.py
@@ -55,6 +55,9 @@ def _i_to_zeek(i, cols):
         if isinstance(y, int):
             y = str(y)
 
+        if isinstance(y, str):
+            y = y.replace('\n', ' ')
+
         if PYVERSION == 2:
             if isinstance(y, unicode):
                 y = y.encode('utf-8')


### PR DESCRIPTION
in https://ja3er.com/getAllUasJson, the User-Agent field contains newline chars (\n) in a few small cases which cause outputting issues for the zeek formatter (the newline is interpreted as a line break in the output). 

If other ingested sources wind up with newlines in the fields, it could create other output issues for the zeek formatter. 

Proposed change replaces newlines in columns of type (str) with a space.