### PR TITLE
fix/dont-lowercase-urls

### DIFF
--- a/csirtg_indicator/indicator.py
+++ b/csirtg_indicator/indicator.py
@@ -211,7 +211,7 @@ class Indicator(object):
     @count.setter
     def count(self, v):
         self._count = int(v)
-        
+
     @count.getter
     def count(self):
         return self._count

--- a/csirtg_indicator/indicator.py
+++ b/csirtg_indicator/indicator.py
@@ -59,7 +59,7 @@ class Indicator(object):
                     kwargs[k] = kwargs[k].lower()
                 if k in ['tags', 'peers']:
                     kwargs[k] = kwargs[k].split(',')
-                    
+
             setattr(self, k, kwargs[k])
 
         self._indicator = None
@@ -90,7 +90,7 @@ class Indicator(object):
         if not i:
             self._indicator = None
             return
-        
+
         if PYVERSION == 2:
             try:
                 i = codecs.unicode_escape_encode(i.decode('utf-8'))[0]
@@ -122,7 +122,7 @@ class Indicator(object):
     @indicator.getter
     def indicator(self):
         return self._indicator
-    
+
     @property
     def confidence(self):
         return self._confidence
@@ -151,7 +151,7 @@ class Indicator(object):
     @property
     def lasttime(self):
         return self._lasttime
-    
+
     @lasttime.getter
     def lasttime(self):
         return self._lasttime
@@ -301,7 +301,7 @@ class Indicator(object):
         except UnicodeDecodeError as e:
             i['asn_desc'] = unicode(i['asn_desc'].decode('latin-1'))
             return json.dumps(i, indent=indent, sort_keys=sort_keys, separators=(',', ': '))
-        
+
     def __eq__(self, other):
         d1 = self.__dict__()
         d2 = other.__dict__()

--- a/csirtg_indicator/indicator.py
+++ b/csirtg_indicator/indicator.py
@@ -31,8 +31,14 @@ class Indicator(object):
 
     def __init__(self, indicator=None, version=PROTOCOL_VERSION, **kwargs):
         self.version = version
-        self._lowercase = True
-        self._lowercase = kwargs.get('lowercase', True)
+        if 'lowercase' in kwargs:
+            self._lowercase = kwargs.get('lowercase')
+            # indicate lowercase arg was explicitly passed by user rather than just a  default value
+            self._lowercase_explicit = True
+        else:
+            # set lowercase to True by default, but ensure we can later determine it was not user specified
+            self._lowercase = True
+            self._lowercase_explicit = False
 
         for k in FIELDS:
             if k in ['indicator', 'confidence', 'count']:  # handle this at the end
@@ -53,7 +59,7 @@ class Indicator(object):
                     kwargs[k] = kwargs[k].lower()
                 if k in ['tags', 'peers']:
                     kwargs[k] = kwargs[k].split(',')
-
+                    
             setattr(self, k, kwargs[k])
 
         self._indicator = None
@@ -84,7 +90,7 @@ class Indicator(object):
         if not i:
             self._indicator = None
             return
-
+        
         if PYVERSION == 2:
             try:
                 i = codecs.unicode_escape_encode(i.decode('utf-8'))[0]
@@ -92,17 +98,19 @@ class Indicator(object):
                 i = codecs.unicode_escape_encode(
                     i.encode('utf-8', 'ignore').decode('utf-8'))[0]
 
-        if self._lowercase is True:
-            i = i.lower()
-        self.itype = resolve_itype(i)
+        self.itype = resolve_itype(i.lower())
         self._indicator = i
 
         if self.itype == 'url':
             u = urlparse(self._indicator)
-            if self._lowercase is True:
+            if self._lowercase is True and self._lowercase_explicit is True:
                 self._indicator = u.geturl().rstrip('/').lower()
             else:
                 self._indicator = u.geturl().rstrip('/')
+        else:
+            if self._lowercase is True:
+                self._indicator = self._indicator.lower()
+
 
         if self.itype == 'ipv4':
             self._indicator = ipv4_normalize(self._indicator)
@@ -114,7 +122,7 @@ class Indicator(object):
     @indicator.getter
     def indicator(self):
         return self._indicator
-
+    
     @property
     def confidence(self):
         return self._confidence
@@ -143,7 +151,7 @@ class Indicator(object):
     @property
     def lasttime(self):
         return self._lasttime
-
+    
     @lasttime.getter
     def lasttime(self):
         return self._lasttime
@@ -178,11 +186,23 @@ class Indicator(object):
 
     @lowercase.setter
     def lowercase(self, v):
-        self._lowercase = float(v)
+        self._lowercase = bool(v)
 
     @lowercase.getter
     def lowercase(self):
         return self._lowercase
+
+    @property
+    def lowercase_explicit(self):
+        return self._lowercase_explicit
+
+    @lowercase.setter
+    def lowercase_explicit(self, v):
+        self._lowercase_explicit = bool(v)
+
+    @lowercase.getter
+    def lowercase_explicit(self):
+        return self._lowercase_explicit
 
     @property
     def count(self):
@@ -191,7 +211,7 @@ class Indicator(object):
     @count.setter
     def count(self, v):
         self._count = int(v)
-
+        
     @count.getter
     def count(self):
         return self._count
@@ -263,7 +283,7 @@ class Indicator(object):
                 v = v.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
             if isinstance(v, basestring):
-                if k is not 'message' and not k.endswith('time') and self._lowercase is False:
+                if k not in ['indicator', 'message'] and not k.endswith('time') and self._lowercase is True:
                     v = v.lower()
 
             if k == 'confidence':
@@ -281,7 +301,7 @@ class Indicator(object):
         except UnicodeDecodeError as e:
             i['asn_desc'] = unicode(i['asn_desc'].decode('latin-1'))
             return json.dumps(i, indent=indent, sort_keys=sort_keys, separators=(',', ': '))
-
+        
     def __eq__(self, other):
         d1 = self.__dict__()
         d2 = other.__dict__()


### PR DESCRIPTION
All indicator types except URLs will now be lowercased by default. A user must explicitly pass lowercase=True to the Indicator() init on a url to get it to actually lowercase it. This is to prevent URLs with case-sensitive paths from not being stored/reflected properly by default.