### PR TITLE
Fix int error

### DIFF
--- a/csirtg_indicator/utils/ztime.py
+++ b/csirtg_indicator/utils/ztime.py
@@ -27,7 +27,11 @@ def parse_timestamp(ts):
     if t:
         return t
 
-    ts_len = len(ts)
+    ts_len = 0
+    if isinstance(ts, str):
+        ts_len = len(ts)
+    elif isinstance(ts, int):
+        ts_len = len(str(ts))
     
     try:
         t = arrow.get(ts)


### PR DESCRIPTION
Handle cases where parse_timestamp is passed an int. func now handles datetime, int, float, str types in the following formats (with specific examples):

- 'YYYY-MM-DD HH:mm:ss': '2020-08-20 21:32:51'
- 'YYYY-MM-DD HH:mm:ss UTC': '2020-08-20 21:32:51 UTC'
- 'YYYYMMDD': '20200820', int(20200820)
- epoch (with and without milliseconds decimal): int(1590673128), float(1590673128), float(1590673128.02), str(1590673128.02),
	str(1590673128)
- 'YYYY-MM-DDTHH:mm:ss': '2020-08-20T21:32:51'
- 'YYYYMMDDTHHmmssZ': '20160219T224322Z'