### PR TITLE
fixes YYYYMMDDHHMMSS timestamps

### DIFF
--- a/csirtg_indicator/utils/ztime.py
+++ b/csirtg_indicator/utils/ztime.py
@@ -58,11 +58,12 @@ def parse_timestamp(ts):
                 pass
 
         if ts_len == 14:
+            # 20210411123448
             match = re.search(r'^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$', ts)
             if match:
                 ts = '{}-{}-{}T{}:{}:{}Z'.format(match.group(1), match.group(2), match.group(3), match.group(4),
                                                  match.group(5), match.group(6))
-                t = arrow.get(ts, 'YYYY-MM-DDTHH:mm:ss')
+                t = arrow.get(ts, ['YYYY-MM-DDTHH:mm:ss', 'YYYY-MM-DDTHH:mm:ssZ'])
                 return t
             else:
                 raise RuntimeError('Invalid Timestamp: %s' % ts)


### PR DESCRIPTION
aligns this function's handling of 14-char timestamp strings with https://github.com/csirtgadgets/cifsdk-py-v3/blob/master/cifsdk/utils/zarrow.py#L30 and fixes the issue where the trailing Z would cause a non-match from arrow.