### PR TITLE
Strip whitespace from str fields

### DIFF
--- a/csirtg_indicator/indicator.py
+++ b/csirtg_indicator/indicator.py
@@ -55,6 +55,9 @@ class Indicator(object):
                 continue
 
             if isinstance(kwargs[k], basestring):
+                # always stripe whitespace
+                kwargs[k] = kwargs[k].strip()
+                
                 if self._lowercase is True:
                     kwargs[k] = kwargs[k].lower()
                 if k in ['tags', 'peers']:
@@ -75,7 +78,7 @@ class Indicator(object):
 
         self._indicator = None
         if indicator:
-            self.indicator = indicator
+            self.indicator = indicator.strip()
 
         self._confidence = 0
         self.confidence = kwargs.get('confidence', 0)


### PR DESCRIPTION
If a source has tabs (\t) at the end of some fields, those currently make it into backend store. This should normalize removing those forms of spurious whitespace.