### PR TITLE
Replace tabs and newlines

### DIFF
--- a/csirtg_indicator/format/zzeek.py
+++ b/csirtg_indicator/format/zzeek.py
@@ -57,7 +57,7 @@ def _i_to_zeek(i, cols):
             y = str(y)
 
         if isinstance(y, str):
-            y = y.replace('\n', ' ')
+            y = re.sub(r'\r|\t|\n', ' ', y)
 
         if PYVERSION == 2:
             if isinstance(y, unicode):


### PR DESCRIPTION
Other whitespace characters like CRs and tabs in fields can misalign formatting. Replace any of those instances in a single field with spaces.